### PR TITLE
Add support for CountAPI as a page counter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Check the *[live demo](https://zivlog.io/monophase/)*.
 - [Disqus](https://disqus.com/)
 - [MathJax](https://www.mathjax.org/)
 - [Google Analytics 4](https://support.google.com/analytics/answer/10089681?hl=en)
+- [CountAPI](https://countapi.xyz)
 - [Jekyll Feed](https://github.com/jekyll/jekyll-feed/)
 - [Jekyll Paginate](https://github.com/jekyll/jekyll-paginate)
 - [Jekyll SEO Tag](https://github.com/jekyll/jekyll-seo-tag/)
@@ -37,6 +38,7 @@ Check the *[live demo](https://zivlog.io/monophase/)*.
   - [Alert Messages](#alert-messages)
   - [Alignment](#alignment)
   - [Google Analytics 4](#google-analytics-4)
+  - [CountAPI](#countapi)
   - [Archive](#archive)
 - [Contributing](#contributing)
 - [Development](#development)
@@ -163,6 +165,15 @@ To enable [Google Analytics 4](https://support.google.com/analytics/answer/10089
 ```yml
 google_analytics: G-XXXXXXX
 ```
+
+### CountAPI
+
+[CountAPI](https://countapi.xyz) is a very simple counting service. It can be enabled to serve as a very basic page counter by setting the CountAPI namespace in your `_config.yml`, for example,
+```yml
+countapi: mysite.github.io
+```
+
+Note that keys are based on `page.url` by eliminating the forward slashes (`/`) and truncating to 63 characters. Keep this in mind when creating documents ([allowed character set for keys](https://countapi.xyz/#format)).
 
 ### Archive
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,10 @@
     </p>
     <p>
       <small>
-        Powered by <a href="https://jekyllrb.com/" target="_blank">Jekyll</a> & <a href="https://github.com/zivhub/monophase" target="_blank">Monophase</a> & <a href="https://countapi.xyz" target="_blank">CountAPI</a>
+        Powered by <a href="https://jekyllrb.com/" target="_blank">Jekyll</a> & <a href="https://github.com/zivhub/monophase" target="_blank">Monophase</a>
+        {% if site.countapi %}
+        & <a href="https://countapi.xyz" target="_blank">CountAPI</a>
+        {% endif %}
       </small>
     </p>
   </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,12 @@
 <footer class="footer">
   <div class="footer-column">
+    {% if site.countapi %}
+    <p>
+      <small>
+        This page has been visited <span id="page_visits">...</span> times.
+      </small>
+    </p>
+    {% endif %}
     <p>
       <small>
         &copy;&nbsp;
@@ -19,7 +26,7 @@
     </p>
     <p>
       <small>
-        Powered by <a href="https://jekyllrb.com/" target="_blank">Jekyll</a> & <a href="https://github.com/zivhub/monophase" target="_blank">Monophase</a>
+        Powered by <a href="https://jekyllrb.com/" target="_blank">Jekyll</a> & <a href="https://github.com/zivhub/monophase" target="_blank">Monophase</a> & <a href="https://countapi.xyz" target="_blank">CountAPI</a>
       </small>
     </p>
   </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   {% if site.countapi %}
   <script>
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/:PATHNAME:");
+    xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/{{ page.url | remove: '/' | slice: 0, 64 }}");
     xhr.responseType = "json";
     xhr.onload = function() {
       document.getElementById('page_visits').textContent = this.response.value;

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,18 @@
   {% seo %}
 
   <script async src="https://use.fontawesome.com/releases/v5.0.12/js/all.js"></script>
-  
+
+  {% if site.countapi %}
+  <script>
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/{{ page.url | remove: '/' | slice: 0, 64 }}/visits");
+    xhr.responseType = "json";
+    xhr.onload = function() {
+      document.getElementById('page_visits').textContent = this.response.value;
+    }
+    xhr.send();
+  </script>
+  {% endif %}
+
   {% include custom-head.html %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   {% if site.countapi %}
   <script>
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/{{ page.url | remove: '/' | slice: 0, 64 }}");
+    xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/:PATHNAME:");
     xhr.responseType = "json";
     xhr.onload = function() {
       document.getElementById('page_visits').textContent = this.response.value;

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
 
   <script async src="https://use.fontawesome.com/releases/v5.0.12/js/all.js"></script>
 
-  {% if site.countapi %}
+  {% if jekyll.environment == 'production' and site.countapi %}
   <script>
     var xhr = new XMLHttpRequest();
     xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/{{ page.url | remove: '/' | slice: 0, 64 }}");

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   {% if site.countapi %}
   <script>
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/{{ page.url | remove: '/' | slice: 0, 64 }}/visits");
+    xhr.open("GET", "https://api.countapi.xyz/hit/{{ site.countapi }}/{{ page.url | remove: '/' | slice: 0, 64 }}");
     xhr.responseType = "json";
     xhr.onload = function() {
       document.getElementById('page_visits').textContent = this.response.value;


### PR DESCRIPTION
CountAPI (https://countapi.xyz/) is a very simple counting service that can be used as page counter. No registration or cookies or anything required. This pull-request adds support for this feature. See https://lcvisser.github.io to see it in use.