### PR TITLE
Scrollable tables

### DIFF
--- a/_sass/monophase/_base.scss
+++ b/_sass/monophase/_base.scss
@@ -84,6 +84,8 @@ table {
   width: 100%;
   border: 0 solid var(--border-color);
   border-collapse: collapse;
+  display: block;
+  overflow: auto;
 }
 
 td,


### PR DESCRIPTION
On mobile, large tables destroy the whole page layout. The whole page is scrollable vertically. This change is taken from the jekyll default theme.